### PR TITLE
Add Streamlit app for harmonic song analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ obteniendo letra y acordes con el formato original (acordes alineados sobre la l
    ```bash
    streamlit run app.py
    ```
-3. Ingresá el nombre de la canción, elegí el resultado correcto y consultá la letra con acordes.
+3. Ingresá el nombre de la canción, elegí el resultado correcto y consultá la letra con acordes. La aplicación muestra toda la información disponible del resultado (p. ej., título y URL) antes de desplegar los acordes.
 
 Las búsquedas normalizan el texto (p. ej., eliminando acentos) para mejorar la compatibilidad con CifraClub.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
-# CancioRepo 🎶
+# Análisis Armónico de Canciones 🎶
 
-Buscador de canciones basado en acordes, con letras y enlaces a CifraClub.
+Aplicación en Streamlit que busca canciones en [CifraClub](https://www.cifraclub.com.br/),
+obteniendo letra y acordes con el formato original (acordes alineados sobre la letra).
 
 ## Cómo usar
 
-1. Desplegar en [Streamlit Cloud](https://streamlit.io/cloud)
-2. Archivo principal: `app.py`
-3. Requiere `streamlit` y `pandas`
+1. Instalar dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Ejecutar la app:
+   ```bash
+   streamlit run app.py
+   ```
+3. Ingresá el nombre de la canción, elegí el resultado correcto y consultá la letra con acordes.
 
----
-Creado con ❤️ usando ChatGPT
+Las búsquedas normalizan el texto (p. ej., eliminando acentos) para mejorar la compatibilidad con CifraClub.
+
+La opción para subir audio aún no está disponible.
+
+El código de scraping se encuentra en `scraper.py`.

--- a/app.py
+++ b/app.py
@@ -1,21 +1,28 @@
 import streamlit as st
-import pandas as pd
+from scraper import search_song, fetch_song
 
-st.set_page_config(page_title="Buscador Armónico de Canciones", layout="centered")
+st.set_page_config(page_title="Análisis Armónico de Canciones", layout="centered")
 
-st.title("🎵 Buscador Armónico de Canciones")
-st.write("Filtrá por acorde para ver qué canciones podés tocar.")
+st.title("🎵 Análisis Armónico de Canciones")
 
-@st.cache_data
-def cargar_datos():
-    return pd.read_csv("analisis_armonico.csv")
+opcion = st.radio("Elegí una opción:", ["Subir audio (próximamente)", "Buscar canción"], index=1)
 
-df = cargar_datos()
-acordes_unicos = sorted(set(sum([ac.split(" - ") for ac in df["Acordes"]], [])))
-
-acorde_seleccionado = st.selectbox("🎸 Elegí un acorde:", acordes_unicos)
-
-resultados = df[df["Acordes"].str.contains(acorde_seleccionado)]
-st.write(f"Se encontraron {len(resultados)} canciones con el acorde **{acorde_seleccionado}**:")
-for _, row in resultados.iterrows():
-    st.markdown(f"- [{row['Título']} - {row['Artista']}]({row['URL']})")
+if opcion.startswith("Subir"):
+    st.info("La subida de audio aún no está disponible.")
+else:
+    consulta = st.text_input("Ingresá nombre de canción o artista")
+    if consulta:
+        resultados = search_song(consulta)
+        if not resultados:
+            st.warning("No se encontraron coincidencias.")
+        else:
+            titulos = [r["title"] for r in resultados]
+            elegido = st.selectbox("Resultados de búsqueda", titulos)
+            url = resultados[titulos.index(elegido)]["url"]
+            if st.button("Mostrar acordes y letra"):
+                contenido = fetch_song(url)
+                if not contenido:
+                    st.error("No se pudo obtener el contenido de la canción.")
+                else:
+                    st.markdown(f"<pre>{contenido}</pre>", unsafe_allow_html=True)
+                    st.download_button("Descargar como TXT", contenido, file_name="cancion.txt")

--- a/app.py
+++ b/app.py
@@ -18,11 +18,15 @@ else:
         else:
             titulos = [r["title"] for r in resultados]
             elegido = st.selectbox("Resultados de búsqueda", titulos)
-            url = resultados[titulos.index(elegido)]["url"]
+            detalles = resultados[titulos.index(elegido)]
+            st.write("Información disponible del resultado seleccionado:")
+            st.json(detalles)
             if st.button("Mostrar acordes y letra"):
-                contenido = fetch_song(url)
+                contenido = fetch_song(detalles["url"])
                 if not contenido:
                     st.error("No se pudo obtener el contenido de la canción.")
                 else:
+                    st.markdown(f"### {detalles['title']}")
+                    st.markdown(f"[Ver en CifraClub]({detalles['url']})")
                     st.markdown(f"<pre>{contenido}</pre>", unsafe_allow_html=True)
                     st.download_button("Descargar como TXT", contenido, file_name="cancion.txt")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 streamlit
-pandas
+requests
+beautifulsoup4
+unidecode
+
+pytest

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,65 @@
+"""Helpers to search and fetch songs from CifraClub.
+
+Search queries are normalized with ``unidecode`` to improve match
+reliability regardless of accents or special characters.
+"""
+
+import requests
+from bs4 import BeautifulSoup
+from unidecode import unidecode
+
+BASE_URL = "https://www.cifraclub.com.br"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+def search_song(query: str):
+    """Search songs on CifraClub.
+
+    The query string is normalized with ``unidecode`` to remove accents
+    before sending the request. Returns a list of dicts with ``title`` and
+    ``url`` keys for each result.
+    """
+    q = unidecode(query).strip()
+    if not q:
+        return []
+    try:
+        response = requests.get(f"{BASE_URL}/busca/", params={"q": q}, headers=HEADERS, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException:
+        return []
+    soup = BeautifulSoup(response.text, "html.parser")
+    results = []
+    for link in soup.select("a.gs-title"):
+        title = link.get_text(strip=True)
+        href = link.get("href", "")
+        if not href:
+            continue
+        if href.startswith("/"):
+            href = BASE_URL + href
+        results.append({"title": title, "url": href})
+    return results
+
+
+def fetch_song(url: str):
+    """Return chord sheet from a CifraClub song url preserving formatting."""
+    try:
+        response = requests.get(url, headers=HEADERS, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException:
+        return None
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    # Most songs use a ``<pre>`` block, but others rely on ``<div class="cifra_cnt">``
+    # or custom elements. Try several selectors before giving up so a wider range
+    # of layouts can be parsed.
+    container = soup.find("pre")
+    if not container:
+        container = soup.find("div", class_="cifra_cnt")
+    if not container:
+        # Fall back to any element whose class includes "cifra"
+        container = soup.find(attrs={"class": lambda c: c and "cifra" in c})
+    if not container:
+        return None
+
+    return container.get_text("\n", strip=False)

--- a/scraper.py
+++ b/scraper.py
@@ -41,7 +41,17 @@ def search_song(query: str):
 
 
 def fetch_song(url: str):
-    """Return chord sheet from a CifraClub song url preserving formatting."""
+    """Fetch chord sheet from a CifraClub song page.
+
+    Tries several selectors in order to locate the chord/lyric block:
+
+    1. ``<pre>``
+    2. ``<div class="cifra_cnt">``
+    3. any element whose ``class`` contains ``"cifra"``
+
+    Returns the extracted text with chords aligned above lyrics, or
+    ``None`` if the request fails or none of the selectors are found.
+    """
     try:
         response = requests.get(url, headers=HEADERS, timeout=10)
         response.raise_for_status()

--- a/test_scraper.py
+++ b/test_scraper.py
@@ -1,0 +1,40 @@
+import requests
+from types import SimpleNamespace
+
+from scraper import search_song, fetch_song
+
+
+def test_search_song_empty_query():
+    assert search_song('') == []
+
+
+def test_search_song_nonsense_returns_empty(monkeypatch):
+    def fake_get(url, params=None, headers=None, timeout=None):
+        html = "<html><body>No results</body></html>"
+        return SimpleNamespace(text=html, raise_for_status=lambda: None)
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert search_song("nonsensezzz") == []
+
+
+def test_fetch_song_http_error_returns_none(monkeypatch):
+    def fake_get(url, headers=None, timeout=None):
+        raise requests.RequestException
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert fetch_song("http://example.com/404") is None
+
+
+def test_fetch_song_no_cifra_elements_returns_none(monkeypatch):
+    def fake_get(url, headers=None, timeout=None):
+        html = "<html><body><div>no chords</div></body></html>"
+        return SimpleNamespace(text=html, raise_for_status=lambda: None)
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert fetch_song("http://example.com/no_chords") is None
+
+
+def test_fetch_song_preserves_alignment(monkeypatch):
+    def fake_get(url, headers=None, timeout=None):
+        html = "<pre>C      G\nLetra de prueba</pre>"
+        return SimpleNamespace(text=html, raise_for_status=lambda: None)
+    monkeypatch.setattr(requests, "get", fake_get)
+    content = fetch_song("http://example.com/song")
+    assert content == "C      G\nLetra de prueba"

--- a/test_scraper.py
+++ b/test_scraper.py
@@ -38,3 +38,12 @@ def test_fetch_song_preserves_alignment(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
     content = fetch_song("http://example.com/song")
     assert content == "C      G\nLetra de prueba"
+
+
+def test_fetch_song_fallback_cifra_class(monkeypatch):
+    def fake_get(url, headers=None, timeout=None):
+        html = '<span class="cifra-blah">C F G<br>Letra de prueba</span>'
+        return SimpleNamespace(text=html, raise_for_status=lambda: None)
+    monkeypatch.setattr(requests, "get", fake_get)
+    content = fetch_song("http://example.com/custom_layout")
+    assert content == "C F G\nLetra de prueba"


### PR DESCRIPTION
## Summary
- Create scraper to search and fetch songs from CifraClub
- Build Streamlit interface to query songs and display chords/lyrics with export
- Document usage, dependencies, and that queries are normalized (accents removed) for compatibility
- Use the `/busca/` endpoint for reliable search results
- Add fallback parsing for song pages that don't use `<pre>` tags
- Add pytest-based tests covering search and fetch edge cases

## Testing
- `python -m py_compile app.py scraper.py`
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68913dc46ad0832ab5e8180be9fe94dc