### PR TITLE
Add Streamlit app for CifraClub chord scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,23 @@
-# Music Analyzer 🎶
+# Análisis Armónico de Canciones 🎶
 
-Herramienta para analizar características musicales de una canción.
+Aplicación en [Streamlit](https://streamlit.io/) para buscar canciones en [CifraClub](https://www.cifraclub.com.br), obtener su letra y acordes y mostrarlos manteniendo el formato original.
 
-Permite obtener tempo (BPM), tonalidad, energía, valence y danceability desde Spotify o analizando archivos MP3/WAV de forma local.
+## Requisitos
+- Python 3.10+
+- Dependencias listadas en `requirements.txt`
 
-## Cómo usar
-
-1. Desplegar en [Streamlit Cloud](https://streamlit.io/cloud) o correr `streamlit run app.py`.
-2. Establecer variables de entorno `SPOTIPY_CLIENT_ID` y `SPOTIPY_CLIENT_SECRET` si vas a analizar canciones de Spotify.
-3. Seleccionar la fuente en la barra lateral: Spotify, MusicBrainz o archivo de audio local.
-4. Introduce la URL/ID de la canción o sube el archivo a analizar.
-5. Para la opción MusicBrainz, ingresa el ID de grabación (MBID) y se mostrarán sus metadatos.
-
-## Despliegue en GitHub y Streamlit
-
-1. Crea un repositorio en GitHub.
-2. Desde tu terminal ejecuta:
+Instálalas con:
 
 ```bash
-git init
-git add .
-git commit -m "Initial commit"
-git branch -M main
-git remote add origin <URL-repo>
-git push -u origin main
+pip install -r requirements.txt
 ```
 
-3. En Streamlit Cloud, selecciona el repositorio público y el archivo `app.py` para lanzar la aplicación.
+## Uso
 
----
-Creado con ❤️ usando ChatGPT
+```bash
+streamlit run app.py
+```
+
+En la interfaz elige **Buscar canción**, ingresa el nombre y selecciona el resultado correcto. Se mostrarán los acordes y la letra alineados como en CifraClub y podrás descargar el texto.
+
+La opción de subir audio se encuentra deshabilitada por el momento.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 streamlit
-librosa
-spotipy
-numpy
-musicbrainzngs
+requests
+beautifulsoup4
+unidecode

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,51 @@
+import re
+from urllib.parse import quote, urljoin
+
+import requests
+from bs4 import BeautifulSoup
+from unidecode import unidecode
+
+BASE_URL = "https://www.cifraclub.com.br"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+def search_songs(query):
+    """Return a list of (title, url) from CifraClub search results."""
+    if not query:
+        return []
+    q = quote(unidecode(query))
+    url = f"{BASE_URL}/?q={q}"
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=10)
+    except requests.RequestException as e:
+        raise RuntimeError("No se pudo realizar la búsqueda.") from e
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"No se pudo realizar la búsqueda (HTTP {resp.status_code})."
+        )
+    soup = BeautifulSoup(resp.text, "html.parser")
+    results = []
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        full_url = urljoin(BASE_URL, href)
+        if re.match(r"https://www.cifraclub.com.br/[^/]+/[^/]+/?$", full_url):
+            title = a.get_text(strip=True)
+            if title and (title, full_url) not in results:
+                results.append((title, full_url))
+    return results
+
+def get_song_chords(url):
+    """Fetch chord and lyric text from a CifraClub song page."""
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=10)
+    except requests.RequestException as e:
+        raise RuntimeError("No se pudo obtener la canción.") from e
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"No se pudo obtener la canción (HTTP {resp.status_code})."
+        )
+    soup = BeautifulSoup(resp.text, "html.parser")
+    pre = soup.find("pre")
+    if not pre:
+        raise RuntimeError("Formato de canción no reconocido.")
+    text = pre.get_text("\n", strip=False)
+    return text.strip("\n")


### PR DESCRIPTION
## Summary
- Replace previous project with Streamlit app to search CifraClub for songs and display chords aligned over lyrics.
- Implement `scraper.py` with helpers to query CifraClub and fetch chord/lyric blocks.
- Simplify requirements and documentation for the new workflow.
- Require users to explicitly choose a search result before downloading chords.
- Handle network request errors in the scraper to avoid unhelpful proxy messages.

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import py_compile
py_compile.compile('app.py')
py_compile.compile('scraper.py')
print('py_compile OK')
PY`
- `streamlit run app.py` *(server started and then stopped)*
- `python - <<'PY'
from scraper import search_songs
try:
    print(search_songs('Soda Stereo - En el septimo dia')[:5])
except Exception as e:
    print('Error:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68926ef6c190832a94eca0ea123b562e